### PR TITLE
Added support for non RFC 4648 compatible Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.6
+ - Add config for Base64 de-/encoding mode (strict or not)
+
 ## 1.0.5
  - Support Logstash API 1.0 only
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ base64 {
 
   Append values to the `tags` field on encode/decode failure. Defaults to `["_base64failure"]`.
 
+* **strict** 
+
+  Toggle Base64 de- and encoding mode. With strict = true the plugin complies with RFC 4648, otherwise with RFC 2045. Defaults to `true` 
+  
 ## Changelog
 
 You can read about all changes in [CHANGELOG.md](CHANGELOG.md).

--- a/logstash-filter-base64.gemspec
+++ b/logstash-filter-base64.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-filter-base64.gemspec
+++ b/logstash-filter-base64.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-base64'
-  s.version = '1.0.5'
+  s.version = '1.0.6.pre'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter helps you encode and decode fields."
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using `logstash-plugin install logstash-filter-base64`. This gem is not a stand-alone program"


### PR DESCRIPTION
As i found out, this plugin wasn't capable of parsing RFC 2045. It fails with an ArgumentError -> see https://ruby-doc.org/stdlib-2.3.0/libdoc/base64/rdoc/Base64.html#method-i-strict_decode64

We weren't able to use this plugin since our input complies only to RFC 2045. So i implement the `strict` trigger to change the behavior of the Base64 de- and encoder.